### PR TITLE
Remove deprecated make variable GLUON_ATH10K_MESH

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -31,8 +31,6 @@ GLUON_DEPRECATED ?= upgrade
 
 GLUON_REGION ?= eu
 
-GLUON_ATH10K_MESH ?= 11s
-
 DEFAULT_GLUON_RELEASE := g$(shell git -C $(shell pwd) log --pretty=format:'%h' -n 1)+s$(shell git -C $(shell pwd)/site log --pretty=format:'%h' -n 1)~$(shell date '+%Y%m%d')
 
 # Allow overriding the release number from the command line


### PR DESCRIPTION
It was renamed in 2018.1 to GLUON_WLAN_MESH and completely dropped in
2020.1